### PR TITLE
feat!: native `help` command used for opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ require("telescope").load_extension("helpgrep")
 ```
 
 No paths are ignored by default, but if you use `lazy.nvim` it is recommended
-to add `vim.fn.stdpath("state") .. "/lazy/readme"` to the `ignore_paths` table
+to add `vim.fn.stdpath("state") .. "/lazy/readme"` to the `ignore_paths` table.
+
+Note that `telescope-helpgrep.nvim` will extend the `select_*` actions to use the native
+`help`, `vert help` and `tab help` commands.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ require("telescope-helpgrep").grep_string({
 ## Setup
 
 `ignore_paths` defines which paths will be ignored by helpgrep
+`mappings` defines mappings overrides
 `default_grep` specifies which telescope built-in to use
 
 ### Defaults
@@ -99,6 +100,7 @@ require("telescope-helpgrep").grep_string({
 ```lua
 local builtin = require("telescope.builtin")({
   ignore_paths = {},
+  mappings = {},
   default_grep = builtin.live_grep,
 })
 ```
@@ -108,6 +110,7 @@ local builtin = require("telescope.builtin")({
 In Telescope setup:
 
 ```lua
+local actions = require("telescope.actions")
 local builtin = require("telescope.builtin")
 
 telescope.setup({
@@ -116,6 +119,16 @@ telescope.setup({
     helpgrep = {
       ignore_paths = {
         vim.fn.stdpath("state") .. "/lazy/readme",
+      },
+      mappings = {
+        i = {
+          ["<CR>"] = actions.select_default,
+          ["<C-v>"] = actions.select_vertical,
+        },
+        n = {
+          ["<CR>"] = actions.select_default,
+          ["<C-s>"] = actions.select_horizontal,
+        }
       },
       default_grep = builtin.live_grep,
     }

--- a/README.md
+++ b/README.md
@@ -92,22 +92,13 @@ require("telescope-helpgrep").grep_string({
 ## Setup
 
 `ignore_paths` defines which paths will be ignored by helpgrep
-`mappings` defines mappings overrides
+`default_grep` specifies which telescope built-in to use
 
 ### Defaults
 
 ```lua
-local actions = require("telescope.actions")
 local builtin = require("telescope.builtin")({
   ignore_paths = {},
-  mappings = {
-    i = {
-      ["<CR>"] = actions.select_tab,
-    },
-    n = {
-      ["<CR>"] = actions.select_tab,
-    },
-  },
   default_grep = builtin.live_grep,
 })
 ```
@@ -117,7 +108,6 @@ local builtin = require("telescope.builtin")({
 In Telescope setup:
 
 ```lua
-local actions = require("telescope.actions")
 local builtin = require("telescope.builtin")
 
 telescope.setup({
@@ -126,16 +116,6 @@ telescope.setup({
     helpgrep = {
       ignore_paths = {
         vim.fn.stdpath("state") .. "/lazy/readme",
-      },
-      mappings = {
-        i = {
-          ["<CR>"] = actions.select_default,
-          ["<C-v>"] = actions.select_vertical,
-        },
-        n = {
-          ["<CR>"] = actions.select_default,
-          ["<C-s>"] = actions.select_horizontal,
-        }
       },
       default_grep = builtin.live_grep,
     }

--- a/lua/telescope-helpgrep/config.lua
+++ b/lua/telescope-helpgrep/config.lua
@@ -6,6 +6,7 @@ M.opts = {}
 
 M.defaults = {
   ignore_paths = {},
+  mappings = {},
   default_grep = builtin.live_grep,
 }
 

--- a/lua/telescope-helpgrep/config.lua
+++ b/lua/telescope-helpgrep/config.lua
@@ -1,4 +1,3 @@
-local actions = require("telescope.actions")
 local builtin = require("telescope.builtin")
 
 local M = {}
@@ -7,14 +6,6 @@ M.opts = {}
 
 M.defaults = {
   ignore_paths = {},
-  mappings = {
-    i = {
-      ["<CR>"] = actions.select_tab,
-    },
-    n = {
-      ["<CR>"] = actions.select_tab,
-    },
-  },
   default_grep = builtin.live_grep,
 }
 

--- a/lua/telescope-helpgrep/init.lua
+++ b/lua/telescope-helpgrep/init.lua
@@ -76,19 +76,21 @@ local function build_opts(opts)
   _opts = vim.tbl_deep_extend("force", _opts, opts or {})
   _opts = vim.tbl_deep_extend("force", _opts, {
     search_dirs = dirs,
-    attach_mappings = function(prompt_bufnr)
-        action_set.select:replace(function(_, cmd)
+    attach_mappings = function()
+        action_set.select:replace(function(prompt_bufnr, type)
           local selection = action_state.get_selected_entry()
           if selection ~= nil then
-            actions.close(prompt_bufnr)
             local help_file = selection.path
             local tag = tag_map[help_file]
-            local row = selection.lnum
-            local col = selection.col
             if tag then
-              open_with_tag(cmd, tag, row, col)
+              actions.close(prompt_bufnr)
+              local row = selection.lnum
+              local col = selection.col
+              open_with_tag(type, tag, row, col)
+              return
             end
           end
+          action_set.edit(prompt_bufnr, action_state.select_key_to_edit_key(type))
         end)
         return true
       end,


### PR DESCRIPTION
Here's my attempt at closing https://github.com/catgoose/telescope-helpgrep.nvim/issues/6

Unfortunately, the solution was not as straightforward as I described in https://github.com/catgoose/telescope-helpgrep.nvim/issues/6, because `help options.txt` works because `options.txt` is itself a tag and `help` doesn't work with any file.

Similarly to `Telescope help_tags` I build an index of helpfile-tag mappings, where for each help file I store one tag it contains. I can then open `help` using this tag and jump to the right location rightaway.

This PR will also open help in a new tab or a new vsplit (again inspired by `Telescope help_tags`). This has a nice advantage of reusing user settings (or defaults) for livegrep, and not having to define any mappings at all. On the other hand, this makes this a breaking change.

What do you think @catgoose?